### PR TITLE
fix(cpln):  cleanup not finding jobs due to incorrect path

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -1047,11 +1047,11 @@ class PrefectAgent:
 
                         for deployment in deployment_list.get("items", []):
                             # If there are no job executions, skip deployment
-                            if not deployment.get("jobExecutions"):
+                            if not deployment.get("status",{}).get("jobExecutions"):
                                 continue
 
                             # Iterate over each job execution to find the target job
-                            for job in deployment["jobExecutions"]:
+                            for job in deployment["status"]["jobExecutions"]:
                                 # Check if the name of the job includes the command id
                                 if command_id not in job.get("name", ""):
                                     continue


### PR DESCRIPTION
The CPLN API returns jobExecutions under deployment.status.jobExecutions, not deployment.jobExecutions

<img width="358" height="293" alt="image" src="https://github.com/user-attachments/assets/d1e3a2e9-1eca-4ea4-82f1-517e4651294f" />
